### PR TITLE
Simplified land and item retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ func main() {
 - `Open(dir string) (*SDK, error)` – Open a UO client directory
 - `(*SDK).Animation(body, action, direction, hue int, preserveHue, firstFrame bool) (*Animation, error)` – Load animation frames
 - `(*SDK).String(id int) (string, error)` – Retrieve localized string
-- `(*SDK).Font() ([]*Font, error)` – Load UO fonts
-- `(*SDK).Hue(id int) (*Hue, error)` – Get hue/color data
+- `(*SDK).Font() ([]Font, error)` – Load UO fonts
+- `(*SDK).Hue(index int) (*Hue, error)` – Get hue/color data
 - `(*SDK).Gump(id int) (*Gump, error)` – Load gump images
-- `(*SDK).Map(id int) (*Map, error)` – Load map data
+- `(*SDK).Map(mapID int) (*TileMap, error)` – Load map data
 - `(*SDK).Land(id int) (*Land, error)` – Load land art tiles
 - `(*SDK).Item(id int) (*Item, error)` – Load static art tiles
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	
+
 	str, _ := sdk.String(3000001)
 	fmt.Println(str)
 }
@@ -55,12 +55,13 @@ func main() {
 - `(*SDK).Hue(id int) (*Hue, error)` – Get hue/color data
 - `(*SDK).Gump(id int) (*Gump, error)` – Load gump images
 - `(*SDK).Map(id int) (*Map, error)` – Load map data
-- `(*SDK).LandArtTile(id int) (*ArtTile, error)` – Load land art tiles
-- `(*SDK).StaticArtTile(id int) (*ArtTile, error)` – Load static art tiles
+- `(*SDK).Land(id int) (*Land, error)` – Load land art tiles
+- `(*SDK).Item(id int) (*Item, error)` – Load static art tiles
 
 ## Contributing
 
 PRs are welcome! Please:
+
 - Follow the established code style and architectural patterns
 - Add doc comments for all exported functions
 - Avoid package-level mutable state

--- a/README.md
+++ b/README.md
@@ -46,17 +46,79 @@ func main() {
 }
 ```
 
-## API Highlights
+## API Reference
+
+### Core SDK Operations
 
 - `Open(dir string) (*SDK, error)` – Open a UO client directory
+- `(*SDK).Close() error` – Close SDK and release resources
+- `(*SDK).BasePath() string` – Get the base directory path
+
+### Animation
+
 - `(*SDK).Animation(body, action, direction, hue int, preserveHue, firstFrame bool) (*Animation, error)` – Load animation frames
+
+### Localization (Cliloc)
+
 - `(*SDK).String(id int) (string, error)` – Retrieve localized string
-- `(*SDK).Font() ([]Font, error)` – Load UO fonts
+- `(*SDK).StringWithLang(id int, lang string) (string, error)` – Retrieve string in specific language
+- `(*SDK).StringEntry(id int, lang string) (StringEntry, error)` – Get string entry with metadata
+- `(*SDK).Strings() iter.Seq2[int, string]` – Iterate over all strings
+- `(*SDK).StringsWithLang(lang string) iter.Seq2[int, string]` – Iterate over strings in specific language
+
+### Fonts
+
+- `(*SDK).Font() ([]Font, error)` – Load ASCII fonts
+- `(*SDK).FontUnicode() (Font, error)` – Load Unicode font
+
+### Hues/Colors
+
 - `(*SDK).Hue(index int) (*Hue, error)` – Get hue/color data
+- `(*SDK).Hues() iter.Seq[*Hue]` – Iterate over all hues
+
+### Gumps (UI Graphics)
+
 - `(*SDK).Gump(id int) (*Gump, error)` – Load gump images
+- `(*SDK).Gumps() iter.Seq[*Gump]` – Iterate over all gumps
+
+### Maps & Tiles
+
 - `(*SDK).Map(mapID int) (*TileMap, error)` – Load map data
 - `(*SDK).Land(id int) (*Land, error)` – Load land art tiles
+- `(*SDK).Lands() iter.Seq[*Land]` – Iterate over all land tiles
 - `(*SDK).Item(id int) (*Item, error)` – Load static art tiles
+- `(*SDK).Items() iter.Seq[*Item]` – Iterate over all static items
+
+### Multi-Tile Objects
+
+- `(*SDK).Multi(id int) (*Multi, error)` – Load multi-tile object
+- `(*SDK).MultiFromCSV(id int) (*Multi, error)` – Load multi from CSV data
+
+### Radar Colors
+
+- `(*SDK).RadarColor(id int) (RadarColor, error)` – Get radar color
+- `(*SDK).RadarColors() iter.Seq[RadarColor]` – Iterate over all radar colors
+
+### Audio
+
+- `(*SDK).Sound(id int) (Sound, error)` – Load sound data
+- `(*SDK).Sounds() iter.Seq[Sound]` – Iterate over all sounds
+- `(*SDK).SpeechEntry(id int) (Speech, error)` – Get speech entry
+- `(*SDK).SpeechEntries() iter.Seq[Speech]` – Iterate over all speech entries
+
+### Skills
+
+- `(*SDK).Skill(id int) (*Skill, error)` – Get skill information
+- `(*SDK).Skills() iter.Seq[*Skill]` – Iterate over all skills
+- `(*SDK).SkillGroup(id int) (*SkillGroup, error)` – Get skill group
+- `(*SDK).SkillGroups() iter.Seq[*SkillGroup]` – Iterate over all skill groups
+
+### Lighting & Textures
+
+- `(*SDK).Light(id int) (Light, error)` – Load light data
+- `(*SDK).Lights() iter.Seq[Light]` – Iterate over all lights
+- `(*SDK).Texture(id int) (Texture, error)` – Load texture data
+- `(*SDK).Textures() iter.Seq[Texture]` – Iterate over all textures
 
 ## Contributing
 

--- a/art.go
+++ b/art.go
@@ -41,10 +41,10 @@ type Land struct {
 	*LandInfo
 }
 
-// Static represents a complete static item with both art and tile data.
-type Static struct {
+// Item represents a complete static item with both art and tile data.
+type Item struct {
 	Art
-	*StaticInfo
+	*ItemInfo
 }
 
 // Land retrieves a land art tile by its ID.
@@ -83,8 +83,8 @@ func (s *SDK) Land(id int) (*Land, error) {
 	}, nil
 }
 
-// Static retrieves a static art tile by its ID.
-func (s *SDK) Static(id int) (*Static, error) {
+// Item retrieves a static art tile by its ID.
+func (s *SDK) Item(id int) (*Item, error) {
 	if id < 0 || id > maxValidArtIndex-staticTileMinID {
 		return nil, fmt.Errorf("%w: static tile ID %d out of range [0-%d]",
 			ErrInvalidTileID, id, maxValidArtIndex-staticTileMinID)
@@ -116,9 +116,9 @@ func (s *SDK) Static(id int) (*Static, error) {
 		return nil, err
 	}
 
-	return &Static{
-		Art:        artTile,
-		StaticInfo: info,
+	return &Item{
+		Art:      artTile,
+		ItemInfo: info,
 	}, nil
 }
 
@@ -138,11 +138,11 @@ func (s *SDK) Lands() iter.Seq[*Land] {
 	}
 }
 
-// Statics returns an iterator over all available static art tiles.
-func (s *SDK) Statics() iter.Seq[*Static] {
-	return func(yield func(*Static) bool) {
+// Items returns an iterator over all available static art tiles.
+func (s *SDK) Items() iter.Seq[*Item] {
+	return func(yield func(*Item) bool) {
 		for i := uint32(staticTileMinID); i <= maxValidArtIndex; i++ {
-			tile, err := s.Static(int(i - staticTileMinID))
+			tile, err := s.Item(int(i - staticTileMinID))
 			if tile == nil || err != nil {
 				continue
 			}

--- a/art.go
+++ b/art.go
@@ -29,30 +29,26 @@ var (
 	ErrInvalidArtData = errors.New("invalid art data")
 )
 
-// ArtTile represents a piece of art (land or static item).
-type ArtTile struct {
-	ID     int         // ID of the tile
-	Name   string      // Name from TileData
-	Flags  TileFlag    // Flags from TileData
-	Height int8        // Height of the tile, from TileData
-	Image  image.Image // Decoded image for the tile
+// Art represents a piece of art (land or static item).
+type Art struct {
+	ID    int         // ID of the tile
+	Image image.Image // Decoded image for the tile
 }
 
-// ArtTile returns an art tile by ID.
-// Use LandArtTile or StaticArtTile for clearer semantics.
-func (s *SDK) ArtTile(id int) (*ArtTile, error) {
-	if id < 0 || id > maxValidArtIndex {
-		return nil, ErrInvalidTileID
-	}
-
-	if id < landTileMax {
-		return s.LandArtTile(id)
-	}
-	return s.StaticArtTile(id - staticTileMinID)
+// Land represents a complete land tile with both art and tile data.
+type Land struct {
+	Art
+	*LandInfo
 }
 
-// LandArtTile retrieves a land art tile by its ID.
-func (s *SDK) LandArtTile(id int) (*ArtTile, error) {
+// Static represents a complete static item with both art and tile data.
+type Static struct {
+	Art
+	*StaticInfo
+}
+
+// Land retrieves a land art tile by its ID.
+func (s *SDK) Land(id int) (*Land, error) {
 	if id < 0 || id >= landTileMax {
 		return nil, fmt.Errorf("%w: land tile ID %d out of range [0-%d]",
 			ErrInvalidTileID, id, landTileMax-1)
@@ -65,24 +61,30 @@ func (s *SDK) LandArtTile(id int) (*ArtTile, error) {
 	}
 
 	// Read the land tile data
-	info, _ := s.LandTile(id)
-	return uofile.Decode(file, uint32(id), func(data []byte, extra uint64) (*ArtTile, error) {
+	info, _ := s.landInfo(id)
+	artTile, err := uofile.Decode(file, uint32(id), func(data []byte, extra uint64) (Art, error) {
 		img, err := decodeLandImage(data)
 		if err != nil {
-			return nil, err
+			return Art{}, err
 		}
 
-		return &ArtTile{
+		return Art{
 			ID:    id,
-			Name:  info.Name,
-			Flags: info.Flags,
 			Image: img,
 		}, nil
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &Land{
+		Art:      artTile,
+		LandInfo: info,
+	}, nil
 }
 
-// StaticArtTile retrieves a static art tile by its ID.
-func (s *SDK) StaticArtTile(id int) (*ArtTile, error) {
+// Static retrieves a static art tile by its ID.
+func (s *SDK) Static(id int) (*Static, error) {
 	if id < 0 || id > maxValidArtIndex-staticTileMinID {
 		return nil, fmt.Errorf("%w: static tile ID %d out of range [0-%d]",
 			ErrInvalidTileID, id, maxValidArtIndex-staticTileMinID)
@@ -98,28 +100,33 @@ func (s *SDK) StaticArtTile(id int) (*ArtTile, error) {
 	}
 
 	// Read the static tile data
-	info, _ := s.StaticTile(id)
-	return uofile.Decode(file, uint32(artID), func(data []byte, extra uint64) (*ArtTile, error) {
+	info, _ := s.staticInfo(id)
+	artTile, err := uofile.Decode(file, uint32(artID), func(data []byte, extra uint64) (Art, error) {
 		img, err := decodeStaticImage(data)
 		if err != nil {
-			return nil, err
+			return Art{}, err
 		}
 
-		return &ArtTile{
-			ID:     artID,
-			Name:   info.Name,
-			Flags:  info.Flags,
-			Height: int8(info.Height),
-			Image:  img,
+		return Art{
+			ID:    artID,
+			Image: img,
 		}, nil
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &Static{
+		Art:        artTile,
+		StaticInfo: info,
+	}, nil
 }
 
-// LandArtTiles returns an iterator over all available land art tiles.
-func (s *SDK) LandArtTiles() iter.Seq[*ArtTile] {
-	return func(yield func(*ArtTile) bool) {
+// Lands returns an iterator over all available land art tiles.
+func (s *SDK) Lands() iter.Seq[*Land] {
+	return func(yield func(*Land) bool) {
 		for i := uint32(0); i < landTileMax; i++ {
-			tile, err := s.LandArtTile(int(i))
+			tile, err := s.Land(int(i))
 			if tile == nil || err != nil {
 				continue
 			}
@@ -131,11 +138,11 @@ func (s *SDK) LandArtTiles() iter.Seq[*ArtTile] {
 	}
 }
 
-// StaticArtTiles returns an iterator over all available static art tiles.
-func (s *SDK) StaticArtTiles() iter.Seq[*ArtTile] {
-	return func(yield func(*ArtTile) bool) {
+// Statics returns an iterator over all available static art tiles.
+func (s *SDK) Statics() iter.Seq[*Static] {
+	return func(yield func(*Static) bool) {
 		for i := uint32(staticTileMinID); i <= maxValidArtIndex; i++ {
-			tile, err := s.StaticArtTile(int(i - staticTileMinID))
+			tile, err := s.Static(int(i - staticTileMinID))
 			if tile == nil || err != nil {
 				continue
 			}

--- a/art_test.go
+++ b/art_test.go
@@ -27,7 +27,7 @@ func TestArt(t *testing.T) {
 		})
 
 		t.Run("StaticArt", func(t *testing.T) {
-			tile, err := sdk.Static(0x0E3D)
+			tile, err := sdk.Item(0x0E3D)
 
 			assert.NoError(t, err)
 			assert.NotNil(t, tile)
@@ -53,7 +53,7 @@ func TestArt(t *testing.T) {
 
 		t.Run("StaticArtImage", func(t *testing.T) {
 			// Test loading and decoding a static art image
-			tile, err := sdk.Static(8000)
+			tile, err := sdk.Item(8000)
 			assert.NoError(t, err)
 			assert.NotNil(t, tile.Image)
 
@@ -96,7 +96,7 @@ func TestArt(t *testing.T) {
 		t.Run("StaticArtTiles_Iterator", func(t *testing.T) {
 			// Test the static art iterator
 			counter := 0
-			for tile := range sdk.Statics() {
+			for tile := range sdk.Items() {
 				assert.NotNil(t, tile)
 				assert.NotNil(t, tile.Art, "ArtTile should not be nil")
 				assert.GreaterOrEqual(t, tile.ID, 0x4000)

--- a/art_test.go
+++ b/art_test.go
@@ -13,7 +13,7 @@ import (
 func TestArt(t *testing.T) {
 	runWith(t, func(sdk *SDK) {
 		t.Run("LandArt", func(t *testing.T) {
-			tile, err := sdk.LandArtTile(0)
+			tile, err := sdk.Land(0)
 
 			assert.NoError(t, err)
 			assert.NotNil(t, tile)
@@ -27,7 +27,7 @@ func TestArt(t *testing.T) {
 		})
 
 		t.Run("StaticArt", func(t *testing.T) {
-			tile, err := sdk.StaticArtTile(0x0E3D)
+			tile, err := sdk.Static(0x0E3D)
 
 			assert.NoError(t, err)
 			assert.NotNil(t, tile)
@@ -39,25 +39,9 @@ func TestArt(t *testing.T) {
 			assert.NoError(t, savePng(tile.Image, "test/art_static.png"))
 		})
 
-		t.Run("ArtTile_Land", func(t *testing.T) {
-			// Test retrieving a land tile with the general-purpose ArtTile method
-			tile, err := sdk.ArtTile(100)
-
-			assert.NoError(t, err)
-			assert.Equal(t, 100, tile.ID)
-		})
-
-		t.Run("ArtTile_Static", func(t *testing.T) {
-			// Test retrieving a static tile with the general-purpose ArtTile method
-			tile, err := sdk.ArtTile(0x4000 + 8000)
-
-			assert.NoError(t, err)
-			assert.Equal(t, 0x4000+8000, tile.ID)
-		})
-
 		t.Run("LandArtImage", func(t *testing.T) {
 			// Test loading and decoding a land art image
-			tile, err := sdk.LandArtTile(100)
+			tile, err := sdk.Land(100)
 			require.NoError(t, err)
 			assert.NotNil(t, tile.Image)
 
@@ -69,7 +53,7 @@ func TestArt(t *testing.T) {
 
 		t.Run("StaticArtImage", func(t *testing.T) {
 			// Test loading and decoding a static art image
-			tile, err := sdk.StaticArtTile(8000)
+			tile, err := sdk.Static(8000)
 			assert.NoError(t, err)
 			assert.NotNil(t, tile.Image)
 
@@ -82,16 +66,13 @@ func TestArt(t *testing.T) {
 		})
 
 		t.Run("InvalidIDs", func(t *testing.T) {
-			// Test negative ID
-			_, err := sdk.ArtTile(-1)
-			assert.Error(t, err)
 
 			// Test invalid land ID
-			_, err = sdk.LandArtTile(-1)
+			_, err := sdk.Land(-1)
 			assert.Error(t, err)
 
 			// Test land ID too large
-			_, err = sdk.LandArtTile(0x4000)
+			_, err = sdk.Land(0x4000)
 			assert.Error(t, err)
 
 		})
@@ -99,8 +80,9 @@ func TestArt(t *testing.T) {
 		t.Run("LandArtTiles_Iterator", func(t *testing.T) {
 			// Test the land art iterator
 			counter := 0
-			for tile := range sdk.LandArtTiles() {
+			for tile := range sdk.Lands() {
 				assert.NotNil(t, tile)
+				assert.NotNil(t, tile.Art, "ArtTile should not be nil")
 				assert.Less(t, tile.ID, 0x4000)
 
 				// Just check the first few to keep test runtime reasonable
@@ -114,8 +96,9 @@ func TestArt(t *testing.T) {
 		t.Run("StaticArtTiles_Iterator", func(t *testing.T) {
 			// Test the static art iterator
 			counter := 0
-			for tile := range sdk.StaticArtTiles() {
+			for tile := range sdk.Statics() {
 				assert.NotNil(t, tile)
+				assert.NotNil(t, tile.Art, "ArtTile should not be nil")
 				assert.GreaterOrEqual(t, tile.ID, 0x4000)
 
 				// Just check the first few to keep test runtime reasonable

--- a/hue.go
+++ b/hue.go
@@ -65,8 +65,8 @@ func (h *Hue) Image(widthPerColor, height int) image.Image {
 	return img
 }
 
-// HueAt retrieves a specific hue by its index
-func (s *SDK) HueAt(index int) (*Hue, error) {
+// Hue retrieves a specific hue by its index
+func (s *SDK) Hue(index int) (*Hue, error) {
 	// Check for valid index range
 	if index < 0 || index >= 3000 {
 		return nil, fmt.Errorf("%w: %d (must be between 0 and 2999)", ErrInvalidHueIndex, index)
@@ -154,7 +154,7 @@ func (s *SDK) HueAt(index int) (*Hue, error) {
 func (s *SDK) Hues() iter.Seq[*Hue] {
 	return func(yield func(*Hue) bool) {
 		for i := 0; i < 3000; i++ {
-			hue, err := s.HueAt(i)
+			hue, err := s.Hue(i)
 			if err != nil {
 				continue // Skip any hues that can't be loaded
 			}

--- a/hue_test.go
+++ b/hue_test.go
@@ -94,7 +94,7 @@ func TestHue_Image(t *testing.T) {
 
 func TestSDK_HueAt(t *testing.T) {
 	runWith(t, func(sdk *SDK) {
-		hue, err := sdk.HueAt(1337)
+		hue, err := sdk.Hue(1337)
 		require.NoError(t, err)
 		assert.Equal(t, 1337, hue.Index)
 		assert.NotEmpty(t, hue.Name)
@@ -108,19 +108,19 @@ func TestSDK_HueAt(t *testing.T) {
 		}
 
 		// Test a hue in the middle of the range
-		hue, err = sdk.HueAt(1000)
+		hue, err = sdk.Hue(1000)
 		require.NoError(t, err)
 		assert.Equal(t, 1000, hue.Index)
 
 		// Test retrieving a hue at the upper end of the range
-		hue, err = sdk.HueAt(2999)
+		hue, err = sdk.Hue(2999)
 		require.NoError(t, err)
 		assert.Equal(t, 2999, hue.Index)
 
 		// Test invalid indices
-		_, err = sdk.HueAt(-1)
+		_, err = sdk.Hue(-1)
 		assert.Error(t, err)
-		_, err = sdk.HueAt(3000)
+		_, err = sdk.Hue(3000)
 		assert.Error(t, err)
 	})
 }
@@ -153,7 +153,7 @@ func TestSDK_Hues(t *testing.T) {
 
 func TestHueColorConversion(t *testing.T) {
 	runWith(t, func(sdk *SDK) {
-		hue, err := sdk.HueAt(1) // Get hue #1 (typically a bright red)
+		hue, err := sdk.Hue(1) // Get hue #1 (typically a bright red)
 		require.NoError(t, err)
 
 		// Get a color from the hue
@@ -182,7 +182,7 @@ func TestHueColorConversion(t *testing.T) {
 
 func TestHueImageRendering(t *testing.T) {
 	runWith(t, func(sdk *SDK) {
-		hue, err := sdk.HueAt(5) // Get a sample hue
+		hue, err := sdk.Hue(5) // Get a sample hue
 		require.NoError(t, err)
 
 		// Generate a small visualization image

--- a/multi.go
+++ b/multi.go
@@ -51,7 +51,7 @@ func (m *Multi) Image() (image.Image, error) {
 	}, 0, len(m.Items))
 
 	for _, item := range m.Items {
-		art, err := m.sdk.StaticArtTile(int(item.Item))
+		art, err := m.sdk.Static(int(item.Item))
 		if err != nil || art == nil {
 			continue
 		}
@@ -114,7 +114,7 @@ func (m *Multi) Image() (image.Image, error) {
 
 	// Second pass: draw tiles at adjusted positions
 	for _, pos := range tilePositions {
-		art, err := m.sdk.StaticArtTile(int(pos.item.Item))
+		art, err := m.sdk.Static(int(pos.item.Item))
 		if err != nil || art == nil {
 			continue
 		}
@@ -252,7 +252,7 @@ func (s *SDK) MultiFromCSV(data []byte) (*Multi, error) {
 		offsetY, err := strconv.ParseInt(record[2], 10, 16)
 		if err != nil {
 			return nil, fmt.Errorf("multi: invalid Y in row %d: %w", rowNum+2, err)
-		}		// Parse OffsetZ
+		} // Parse OffsetZ
 		offsetZ, err := strconv.ParseInt(record[3], 10, 16)
 		if err != nil {
 			return nil, fmt.Errorf("multi: invalid Z in row %d: %w", rowNum+2, err)
@@ -266,7 +266,7 @@ func (s *SDK) MultiFromCSV(data []byte) (*Multi, error) {
 				return nil, fmt.Errorf("multi: invalid Flags in row %d: %w", rowNum+2, err)
 			}
 			flags = uint32(flagsVal)
-		}		// Parse cliloc (optional, defaults to 0)
+		} // Parse cliloc (optional, defaults to 0)
 		var cliloc uint32
 		if len(record) > 5 {
 			clilocVal, err := strconv.ParseUint(record[5], 10, 32)
@@ -275,7 +275,7 @@ func (s *SDK) MultiFromCSV(data []byte) (*Multi, error) {
 			}
 			cliloc = uint32(clilocVal)
 		}
-		
+
 		items = append(items, MultiItem{
 			Item:   uint16(itemID),
 			X:      int16(offsetX),

--- a/multi.go
+++ b/multi.go
@@ -51,7 +51,7 @@ func (m *Multi) Image() (image.Image, error) {
 	}, 0, len(m.Items))
 
 	for _, item := range m.Items {
-		art, err := m.sdk.Static(int(item.Item))
+		art, err := m.sdk.Item(int(item.Item))
 		if err != nil || art == nil {
 			continue
 		}
@@ -114,7 +114,7 @@ func (m *Multi) Image() (image.Image, error) {
 
 	// Second pass: draw tiles at adjusted positions
 	for _, pos := range tilePositions {
-		art, err := m.sdk.Static(int(pos.item.Item))
+		art, err := m.sdk.Item(int(pos.item.Item))
 		if err != nil || art == nil {
 			continue
 		}

--- a/tiledata_test.go
+++ b/tiledata_test.go
@@ -7,13 +7,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestTileData(t *testing.T) {
 	runWith(t, func(sdk *SDK) {
 		t.Run("LandTile", func(t *testing.T) {
-			landTile, err := sdk.LandTile(0)
+			landTile, err := sdk.landInfo(0)
 
 			assert.NoError(t, err)
 			assert.NotEmpty(t, landTile.Name) // ED
@@ -21,91 +20,28 @@ func TestTileData(t *testing.T) {
 		})
 
 		t.Run("LandTile_InvalidID", func(t *testing.T) {
-			_, err := sdk.LandTile(-1)
+			_, err := sdk.landInfo(-1)
 			assert.Error(t, err)
 
-			_, err = sdk.LandTile(0xFFFFF)
+			_, err = sdk.landInfo(0xFFFFF)
 			assert.Error(t, err)
 		})
 
 		t.Run("StaticTile", func(t *testing.T) {
-			staticTile, err := sdk.StaticTile(3)
+			staticTile, err := sdk.staticInfo(3)
 
 			assert.NoError(t, err)
 			assert.NotEmpty(t, staticTile.Name)
 		})
 
 		t.Run("StaticTile_InvalidID", func(t *testing.T) {
-			_, err := sdk.StaticTile(-1)
+			_, err := sdk.staticInfo(-1)
 			assert.Error(t, err)
 
-			_, err = sdk.StaticTile(sdk.staticTileCount())
+			_, err = sdk.staticInfo(sdk.staticTileCount())
 			assert.Error(t, err)
 		})
 
-		t.Run("LandTiles_Iterator", func(t *testing.T) {
-			count := 0
-			for tile := range sdk.LandTiles() {
-				if tile.Name != "" {
-					count++
-				}
-				if count >= 5 {
-					break
-				}
-			}
-			assert.Equal(t, 5, count)
-		})
-
-		t.Run("StaticTiles_Iterator", func(t *testing.T) {
-			count := 0
-			for tile := range sdk.StaticTiles() {
-				if tile.Name != "" {
-					count++
-				}
-				if count >= 5 {
-					break
-				}
-			}
-			assert.Equal(t, 5, count)
-		})
-
-		t.Run("StaticItemData_Properties", func(t *testing.T) {
-			// Test some properties that are commonly used
-
-			// Find a known bridge tile to test CalcHeight
-			var bridgeTile StaticItemData
-			bridgeFound := false
-
-			for tile := range sdk.StaticTiles() {
-				if tile.Flags&TileFlagBridge != 0 {
-					bridgeTile = tile
-					bridgeFound = true
-					break
-				}
-			}
-
-			if bridgeFound {
-				assert.Equal(t, int(bridgeTile.Height)/2, bridgeTile.CalcHeight())
-			}
-
-			// Test flag helper methods on some tile
-			staticTile, err := sdk.StaticTile(1)
-			require.NoError(t, err)
-
-			assert.Equal(t, staticTile.Flags&TileFlagBackground != 0, staticTile.Background())
-			assert.Equal(t, staticTile.Flags&TileFlagBridge != 0, staticTile.Bridge())
-			assert.Equal(t, staticTile.Flags&TileFlagImpassable != 0, staticTile.Impassable())
-			assert.Equal(t, staticTile.Flags&TileFlagSurface != 0, staticTile.Surface())
-			assert.Equal(t, staticTile.Flags&TileFlagWearable != 0, staticTile.Wearable())
-		})
-
-		t.Run("HeightTable", func(t *testing.T) {
-			heights, err := sdk.HeightTable()
-
-			assert.NoError(t, err)
-			assert.NotNil(t, heights)
-			assert.Len(t, heights, sdk.staticTileCount())
-		})
 	})
 }
 

--- a/tiledata_test.go
+++ b/tiledata_test.go
@@ -64,4 +64,68 @@ func TestTileData_Helpers(t *testing.T) {
 		assert.Equal(t, "", result)
 	})
 
+	t.Run("ItemInfo_ContextualMethods", func(t *testing.T) {
+		// Test a mock weapon item
+		weaponItem := ItemInfo{
+			Flags:    TileFlagWeapon,
+			Quantity: 5, // Weapon class
+		}
+
+		// Test IsWeapon returns both value and bool
+		weaponClass, isWeapon := weaponItem.IsWeapon()
+		assert.True(t, isWeapon)
+		assert.Equal(t, byte(5), weaponClass)
+
+		// Test IsArmor returns false for weapon
+		_, isArmor := weaponItem.IsArmor()
+		assert.False(t, isArmor)
+
+		// Test a mock wearable item
+		wearableItem := ItemInfo{
+			Flags:   TileFlagWearable,
+			Quality: 10, // Layer
+		}
+
+		// Test IsWearable returns both value and bool
+		layer, isWearable := wearableItem.IsWearable()
+		assert.True(t, isWearable)
+		assert.Equal(t, byte(10), layer)
+
+		// Test convenience Layer() method
+		assert.Equal(t, byte(10), wearableItem.Layer())
+
+		// Test a mock light source
+		lightItem := ItemInfo{
+			Flags:   TileFlagLightSource,
+			Quality: 3, // Light ID
+		}
+
+		// Test IsLightSource returns both value and bool
+		lightID, isLight := lightItem.IsLightSource()
+		assert.True(t, isLight)
+		assert.Equal(t, byte(3), lightID)
+
+		// Test convenience LightID() method
+		assert.Equal(t, byte(3), lightItem.LightID())
+
+		// Test item with no special flags
+		normalItem := ItemInfo{
+			Flags:    TileFlagNone,
+			Quality:  1,
+			Quantity: 2,
+		}
+
+		_, isWeapon = normalItem.IsWeapon()
+		assert.False(t, isWeapon)
+
+		_, isWearable = normalItem.IsWearable()
+		assert.False(t, isWearable)
+
+		_, isLight = normalItem.IsLightSource()
+		assert.False(t, isLight)
+
+		// Test StackQuantity always returns Quantity
+		assert.Equal(t, byte(2), normalItem.StackQuantity())
+	})
+
 }


### PR DESCRIPTION
This pull request refactors the handling of art tiles and hues in the SDK to improve clarity and consistency. Key changes include renaming and restructuring types and methods for better semantics, updating related tests, and removing unused imports.

### Refactoring of Art Tiles:

* Replaced the `ArtTile` type with a more generic `Art` type and introduced `Land` and `Item` types to encapsulate specific tile data. (`art.go`, [art.goL32-R51](diffhunk://#diff-8bb60e9d7e5a647365fc8152ce86ba44e0d14e5d5bd824068a51baed5d92449dL32-R51))
* Renamed methods `LandArtTile` and `StaticArtTile` to `Land` and `Item`, respectively, and updated their implementations to use the new `Land` and `Item` types. (`art.go`, [[1]](diffhunk://#diff-8bb60e9d7e5a647365fc8152ce86ba44e0d14e5d5bd824068a51baed5d92449dL68-R87) [[2]](diffhunk://#diff-8bb60e9d7e5a647365fc8152ce86ba44e0d14e5d5bd824068a51baed5d92449dL101-R129)
* Updated iterators `LandArtTiles` and `StaticArtTiles` to `Lands` and `Items`, reflecting the new type names. (`art.go`, [art.goL134-R145](diffhunk://#diff-8bb60e9d7e5a647365fc8152ce86ba44e0d14e5d5bd824068a51baed5d92449dL134-R145))

### Updates to Hue Handling:

* Renamed the `HueAt` method to `Hue` for consistency with other SDK methods. (`hue.go`, [hue.goL68-R69](diffhunk://#diff-bb143d8a2c53cae5cc4d2541d04f0f1eeef31dbfe88b630a0e38f2be4412e083L68-R69))
* Updated all references to `HueAt` in tests to use the new `Hue` method. (`hue_test.go`, [[1]](diffhunk://#diff-944f6676b6880cb5b0d0bf9e3aeeea564dbda49686566c447df2456af3fecf18L97-R97) [[2]](diffhunk://#diff-944f6676b6880cb5b0d0bf9e3aeeea564dbda49686566c447df2456af3fecf18L111-R123) [[3]](diffhunk://#diff-944f6676b6880cb5b0d0bf9e3aeeea564dbda49686566c447df2456af3fecf18L156-R156) [[4]](diffhunk://#diff-944f6676b6880cb5b0d0bf9e3aeeea564dbda49686566c447df2456af3fecf18L185-R185)

### Test Updates:

* Updated test cases to align with the renamed methods and refactored types (`Land`, `Item`, `Hue`). (`art_test.go`, [[1]](diffhunk://#diff-78de24d1dbe6180dd49b454db3daca5454fc0bc0d8a9515e636c8be495b34fb6L16-R16) [[2]](diffhunk://#diff-78de24d1dbe6180dd49b454db3daca5454fc0bc0d8a9515e636c8be495b34fb6L30-R30) [[3]](diffhunk://#diff-78de24d1dbe6180dd49b454db3daca5454fc0bc0d8a9515e636c8be495b34fb6L42-R44) [[4]](diffhunk://#diff-78de24d1dbe6180dd49b454db3daca5454fc0bc0d8a9515e636c8be495b34fb6L72-R56) [[5]](diffhunk://#diff-78de24d1dbe6180dd49b454db3daca5454fc0bc0d8a9515e636c8be495b34fb6L85-R85) [[6]](diffhunk://#diff-78de24d1dbe6180dd49b454db3daca5454fc0bc0d8a9515e636c8be495b34fb6L117-R101)
* Removed tests for the deprecated `ArtTile` method. (`art_test.go`, [art_test.goL42-R44](diffhunk://#diff-78de24d1dbe6180dd49b454db3daca5454fc0bc0d8a9515e636c8be495b34fb6L42-R44))

### Miscellaneous Changes:

* Updated the `Multi.Image` method to use the new `Item` method instead of `StaticArtTile`. (`multi.go`, [[1]](diffhunk://#diff-dcc9270c162b7bb8b6419f0a6d5a6c4adc7d6d0c86db55c9c28eba223b81e7d7L54-R54) [[2]](diffhunk://#diff-dcc9270c162b7bb8b6419f0a6d5a6c4adc7d6d0c86db55c9c28eba223b81e7d7L117-R117)
* Removed an unused import (`iter`) from `tiledata.go`. (`tiledata.go`, [tiledata.goL10](diffhunk://#diff-6664f36e26573a0bb6ea5489606cbd9f77b4cbda4130916a267a65910b23877fL10))