### PR TITLE
Improve mock SDK Add & error handling

### DIFF
--- a/mock/sdk.go
+++ b/mock/sdk.go
@@ -1,0 +1,440 @@
+package mock
+
+import (
+	"errors"
+	"image"
+
+	"github.com/kelindar/ultima-sdk"
+	"iter"
+)
+
+var ErrNotFound = errors.New("not found")
+
+// SDK is a lightweight in-memory implementation of the ultima.Interface.
+type SDK struct {
+	LandsMap       map[int]*ultima.Land
+	ItemsMap       map[int]*ultima.Item
+	GumpsMap       map[int]*ultima.Gump
+	HuesMap        map[int]*ultima.Hue
+	LightsMap      map[int]ultima.Light
+	RadarColorMap  map[int]ultima.RadarColor
+	SkillsMap      map[int]*ultima.Skill
+	SkillGroupsMap map[int]*ultima.SkillGroup
+	SoundsMap      map[int]*ultima.Sound
+	TexturesMap    map[int]*ultima.Texture
+	SpeechMap      map[int]ultima.Speech
+	StringsMap     map[string]map[int]string
+	MultisMap      map[int]*ultima.Multi
+	MapsMap        map[int]*TileMap
+	UnicodeFont    ultima.Font
+	Fonts          []ultima.Font
+	nextStringID   int
+}
+
+// New creates an empty mock SDK.
+func New() *SDK {
+	return &SDK{
+		LandsMap:       make(map[int]*ultima.Land),
+		ItemsMap:       make(map[int]*ultima.Item),
+		GumpsMap:       make(map[int]*ultima.Gump),
+		HuesMap:        make(map[int]*ultima.Hue),
+		LightsMap:      make(map[int]ultima.Light),
+		RadarColorMap:  make(map[int]ultima.RadarColor),
+		SkillsMap:      make(map[int]*ultima.Skill),
+		SkillGroupsMap: make(map[int]*ultima.SkillGroup),
+		SoundsMap:      make(map[int]*ultima.Sound),
+		TexturesMap:    make(map[int]*ultima.Texture),
+		SpeechMap:      make(map[int]ultima.Speech),
+		StringsMap:     make(map[string]map[int]string),
+		MultisMap:      make(map[int]*ultima.Multi),
+		MapsMap:        make(map[int]*TileMap),
+	}
+}
+
+// Open mirrors ultima.Open but simply returns an empty SDK.
+func Open(_ string) (*SDK, error) { return New(), nil }
+
+// Add registers the given value into the mock SDK.
+func (s *SDK) Add(v any) {
+	switch x := v.(type) {
+	case *ultima.Land:
+		s.LandsMap[x.ID] = x
+	case *ultima.Item:
+		s.ItemsMap[x.ID] = x
+	case *ultima.Gump:
+		s.GumpsMap[x.ID] = x
+	case *ultima.Hue:
+		s.HuesMap[x.Index] = x
+	case ultima.Light:
+		s.LightsMap[x.ID] = x
+	case *ultima.Light:
+		s.LightsMap[x.ID] = *x
+	case ultima.RadarColor:
+		s.RadarColorMap[x.ID()] = x
+	case *ultima.Skill:
+		s.SkillsMap[x.ID] = x
+	case *ultima.SkillGroup:
+		s.SkillGroupsMap[x.ID] = x
+	case *ultima.Sound:
+		s.SoundsMap[x.Index] = x
+	case *ultima.Texture:
+		s.TexturesMap[x.Index] = x
+	case ultima.Speech:
+		s.SpeechMap[x.ID()] = x
+	case LocalizedString:
+		m, ok := s.StringsMap[x.Lang]
+		if !ok {
+			m = make(map[int]string)
+			s.StringsMap[x.Lang] = m
+		}
+		m[x.ID] = x.Text
+		if x.ID >= s.nextStringID {
+			s.nextStringID = x.ID + 1
+		}
+	case string:
+		m, ok := s.StringsMap["enu"]
+		if !ok {
+			m = make(map[int]string)
+			s.StringsMap["enu"] = m
+		}
+		m[s.nextStringID] = x
+		s.nextStringID++
+	case *TileMap:
+		s.MapsMap[x.ID] = x
+	case MultiEntry:
+		s.MultisMap[x.ID] = x.Multi
+	}
+}
+
+// Close is a no-op for the mock SDK.
+func (*SDK) Close() error { return nil }
+
+// BasePath returns an empty string.
+func (*SDK) BasePath() string { return "" }
+
+// Animation returns a stored animation if present.
+func (s *SDK) Animation(body, action, direction, hue int, preserveHue, firstFrame bool) (*ultima.Animation, error) {
+	return nil, errors.New("mock: animation not implemented")
+}
+
+// Land returns a stored land tile.
+func (s *SDK) Land(id int) (*ultima.Land, error) {
+	v, ok := s.LandsMap[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return v, nil
+}
+
+// Item returns a stored item tile.
+func (s *SDK) Item(id int) (*ultima.Item, error) {
+	v, ok := s.ItemsMap[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return v, nil
+}
+
+// Lands iterates over stored lands.
+func (s *SDK) Lands() iter.Seq[*ultima.Land] {
+	return func(yield func(*ultima.Land) bool) {
+		for _, v := range s.LandsMap {
+			if !yield(v) {
+				break
+			}
+		}
+	}
+}
+
+// Items iterates over stored items.
+func (s *SDK) Items() iter.Seq[*ultima.Item] {
+	return func(yield func(*ultima.Item) bool) {
+		for _, v := range s.ItemsMap {
+			if !yield(v) {
+				break
+			}
+		}
+	}
+}
+
+// String retrieves a string in default language "enu".
+func (s *SDK) String(id int) (string, error) {
+	return s.StringWithLang(id, "enu")
+}
+
+// StringWithLang retrieves a localized string.
+func (s *SDK) StringWithLang(id int, lang string) (string, error) {
+	if m, ok := s.StringsMap[lang]; ok {
+		if v, ok := m[id]; ok {
+			return v, nil
+		}
+	}
+	return "", ErrNotFound
+}
+
+// StringEntry returns a StringEntry for the given id and lang.
+func (s *SDK) StringEntry(id int, lang string) (ultima.StringEntry, error) {
+	txt, err := s.StringWithLang(id, lang)
+	if err != nil {
+		return nil, err
+	}
+	b := make([]byte, 5+len(txt))
+	b[4] = 0 // flag
+	copy(b[5:], txt)
+	return ultima.StringEntry(b), nil
+}
+
+// Strings iterates over English strings.
+func (s *SDK) Strings() iter.Seq2[int, string] {
+	return s.StringsWithLang("enu")
+}
+
+// StringsWithLang iterates over strings for a language.
+func (s *SDK) StringsWithLang(lang string) iter.Seq2[int, string] {
+	m := s.StringsMap[lang]
+	return func(yield func(int, string) bool) {
+		for id, txt := range m {
+			if !yield(id, txt) {
+				break
+			}
+		}
+	}
+}
+
+func (s *SDK) FontUnicode() (ultima.Font, error) {
+	if s.UnicodeFont == nil {
+		return nil, ErrNotFound
+	}
+	return s.UnicodeFont, nil
+}
+
+func (s *SDK) Font() ([]ultima.Font, error) {
+	if len(s.Fonts) == 0 {
+		return nil, ErrNotFound
+	}
+	return s.Fonts, nil
+}
+
+func (s *SDK) Gump(id int) (*ultima.Gump, error) {
+	v, ok := s.GumpsMap[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return v, nil
+}
+
+func (s *SDK) Gumps() iter.Seq[*ultima.Gump] {
+	return func(yield func(*ultima.Gump) bool) {
+		for _, g := range s.GumpsMap {
+			if !yield(g) {
+				break
+			}
+		}
+	}
+}
+
+func (s *SDK) Hue(index int) (*ultima.Hue, error) {
+	v, ok := s.HuesMap[index]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return v, nil
+}
+
+func (s *SDK) Hues() iter.Seq[*ultima.Hue] {
+	return func(yield func(*ultima.Hue) bool) {
+		for _, h := range s.HuesMap {
+			if !yield(h) {
+				break
+			}
+		}
+	}
+}
+
+func (s *SDK) Light(id int) (ultima.Light, error) {
+	v, ok := s.LightsMap[id]
+	if !ok {
+		return ultima.Light{}, ErrNotFound
+	}
+	return v, nil
+}
+
+func (s *SDK) Lights() iter.Seq[ultima.Light] {
+	return func(yield func(ultima.Light) bool) {
+		for _, l := range s.LightsMap {
+			if !yield(l) {
+				break
+			}
+		}
+	}
+}
+
+func (s *SDK) Map(mapID int) (*TileMap, error) {
+	v, ok := s.MapsMap[mapID]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return v, nil
+}
+
+func (s *SDK) Multi(id int) (*ultima.Multi, error) {
+	v, ok := s.MultisMap[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return v, nil
+}
+
+func (s *SDK) MultiFromCSV(data []byte) (*ultima.Multi, error) {
+	return nil, errors.New("mock: MultiFromCSV not implemented")
+}
+
+func (s *SDK) RadarColor(tileID int) (ultima.RadarColor, error) {
+	v, ok := s.RadarColorMap[tileID]
+	if !ok {
+		return 0, ErrNotFound
+	}
+	return v, nil
+}
+
+func (s *SDK) RadarColors() iter.Seq[ultima.RadarColor] {
+	return func(yield func(ultima.RadarColor) bool) {
+		for _, c := range s.RadarColorMap {
+			if !yield(c) {
+				break
+			}
+		}
+	}
+}
+
+func (s *SDK) Skill(id int) (*ultima.Skill, error) {
+	v, ok := s.SkillsMap[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return v, nil
+}
+
+func (s *SDK) Skills() iter.Seq[*ultima.Skill] {
+	return func(yield func(*ultima.Skill) bool) {
+		for _, sk := range s.SkillsMap {
+			if !yield(sk) {
+				break
+			}
+		}
+	}
+}
+
+func (s *SDK) SkillGroup(id int) (*ultima.SkillGroup, error) {
+	v, ok := s.SkillGroupsMap[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return v, nil
+}
+
+func (s *SDK) SkillGroups() iter.Seq[*ultima.SkillGroup] {
+	return func(yield func(*ultima.SkillGroup) bool) {
+		for _, sg := range s.SkillGroupsMap {
+			if !yield(sg) {
+				break
+			}
+		}
+	}
+}
+
+func (s *SDK) Sound(index int) (*ultima.Sound, error) {
+	v, ok := s.SoundsMap[index]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return v, nil
+}
+
+func (s *SDK) Sounds() func(yield func(*ultima.Sound) bool) {
+	return func(yield func(*ultima.Sound) bool) {
+		for _, snd := range s.SoundsMap {
+			if !yield(snd) {
+				break
+			}
+		}
+	}
+}
+
+func (s *SDK) SpeechEntry(id int) (ultima.Speech, error) {
+	v, ok := s.SpeechMap[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return v, nil
+}
+
+func (s *SDK) SpeechEntries() iter.Seq[ultima.Speech] {
+	return func(yield func(ultima.Speech) bool) {
+		for _, sp := range s.SpeechMap {
+			if !yield(sp) {
+				break
+			}
+		}
+	}
+}
+
+func (s *SDK) Texture(index int) (*ultima.Texture, error) {
+	v, ok := s.TexturesMap[index]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return v, nil
+}
+
+func (s *SDK) Textures() func(yield func(*ultima.Texture) bool) {
+	return func(yield func(*ultima.Texture) bool) {
+		for _, t := range s.TexturesMap {
+			if !yield(t) {
+				break
+			}
+		}
+	}
+}
+
+// ---------------------- TileMap ----------------------
+
+// TileMap is a minimal in-memory implementation of ultima.TileMap.
+type TileMap struct {
+	ID     int
+	Width  int
+	Height int
+	Tiles  map[[2]int]*ultima.Tile
+}
+
+// TileAt retrieves a stored tile.
+func (m *TileMap) TileAt(x, y int) (*ultima.Tile, error) {
+	if m == nil {
+		return nil, errors.New("nil tilemap")
+	}
+	if t, ok := m.Tiles[[2]int{x, y}]; ok {
+		return t, nil
+	}
+	return nil, ErrNotFound
+}
+
+// Image returns a blank image of the correct size.
+func (m *TileMap) Image() (image.Image, error) {
+	if m == nil {
+		return nil, errors.New("nil tilemap")
+	}
+	return image.NewRGBA(image.Rect(0, 0, m.Width, m.Height)), nil
+}
+
+// ---------------------- Helpers ----------------------
+
+type LocalizedString struct {
+	Lang string
+	ID   int
+	Text string
+}
+
+type MultiEntry struct {
+	ID    int
+	Multi *ultima.Multi
+}

--- a/mock/sdk_test.go
+++ b/mock/sdk_test.go
@@ -1,0 +1,253 @@
+package mock
+
+import (
+	"testing"
+
+	"github.com/kelindar/ultima-sdk"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockSDK_AddAndRetrieve(t *testing.T) {
+	sdk := New()
+	land := &ultima.Land{Art: ultima.Art{ID: 1}}
+	sdk.Add(land)
+
+	got, err := sdk.Land(1)
+	assert.NoError(t, err)
+	assert.Equal(t, land, got)
+
+	sdk.Add(LocalizedString{Lang: "enu", ID: 100, Text: "hello"})
+	txt, err := sdk.String(100)
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", txt)
+
+	id := sdk.nextStringID
+	sdk.Add("world")
+	txt, err = sdk.String(id)
+	assert.NoError(t, err)
+	assert.Equal(t, "world", txt)
+}
+
+// dummyFont implements ultima.Font for testing purposes.
+type dummyFont struct{}
+
+func (dummyFont) Character(r rune) *ultima.FontRune { return &ultima.FontRune{} }
+func (dummyFont) Size(string) (int, int)            { return 0, 0 }
+
+// setup creates a mock SDK populated with sample data covering the full
+// exported surface of the SDK type.
+func setup() *SDK {
+	sdk := New()
+
+	// Core data types
+	sdk.Add(&ultima.Land{Art: ultima.Art{ID: 1}})
+	sdk.Add(&ultima.Item{Art: ultima.Art{ID: 2}})
+	sdk.Add(&ultima.Gump{ID: 3, Width: 1, Height: 2})
+	sdk.Add(&ultima.Hue{Index: 4, Name: "h"})
+	sdk.Add(ultima.Light{ID: 5, Width: 1, Height: 1})
+	sdk.Add(ultima.RadarColor(6 | (0x1234 << 32)))
+	sdk.Add(&ultima.Skill{ID: 7, Name: "test"})
+	sdk.Add(&ultima.SkillGroup{ID: 8, Name: "grp", Skills: []int{7}})
+	sdk.Add(&ultima.Sound{Index: 9, Length: 1, Name: "s"})
+	sdk.Add(&ultima.Texture{Index: 10, Size: 64})
+	sdk.Add(ultima.Speech([]byte{0, 11, 'h', 'i'}))
+	sdk.Add(LocalizedString{Lang: "enu", ID: 12, Text: "hello"})
+
+	// Map and multi structures
+	tm := &TileMap{ID: 13, Width: 2, Height: 2, Tiles: map[[2]int]*ultima.Tile{
+		{1, 1}: {ID: 0x100},
+	}}
+	sdk.Add(tm)
+	sdk.Add(MultiEntry{ID: 14, Multi: &ultima.Multi{Items: []ultima.MultiItem{{Item: 1}}}})
+
+	// Fonts
+	sdk.UnicodeFont = dummyFont{}
+	sdk.Fonts = []ultima.Font{dummyFont{}}
+
+	return sdk
+}
+
+// TestMockSDK_Methods exercises all exported methods of the mock SDK
+// to ensure they behave consistently with the in-memory data.
+func TestMockSDK_Methods(t *testing.T) {
+	sdk := setup()
+
+	// Animation is not implemented and should error
+	_, err := sdk.Animation(0, 0, 0, 0, false, false)
+	assert.Error(t, err)
+
+	// Basic lookup methods
+	if land, err := sdk.Land(1); assert.NoError(t, err) {
+		assert.Equal(t, 1, land.ID)
+	}
+	if item, err := sdk.Item(2); assert.NoError(t, err) {
+		assert.Equal(t, 2, item.ID)
+	}
+	if gump, err := sdk.Gump(3); assert.NoError(t, err) {
+		assert.Equal(t, 3, gump.ID)
+	}
+	if hue, err := sdk.Hue(4); assert.NoError(t, err) {
+		assert.Equal(t, 4, hue.Index)
+	}
+	if l, err := sdk.Light(5); assert.NoError(t, err) {
+		assert.Equal(t, 5, l.ID)
+	}
+	if rc, err := sdk.RadarColor(6); assert.NoError(t, err) {
+		assert.Equal(t, ultima.RadarColor(6|(0x1234<<32)), rc)
+	}
+	if sk, err := sdk.Skill(7); assert.NoError(t, err) {
+		assert.Equal(t, 7, sk.ID)
+	}
+	if sg, err := sdk.SkillGroup(8); assert.NoError(t, err) {
+		assert.Equal(t, 8, sg.ID)
+	}
+	if snd, err := sdk.Sound(9); assert.NoError(t, err) {
+		assert.Equal(t, 9, snd.Index)
+	}
+	if tex, err := sdk.Texture(10); assert.NoError(t, err) {
+		assert.Equal(t, 10, tex.Index)
+	}
+	if sp, err := sdk.SpeechEntry(11); assert.NoError(t, err) {
+		assert.Equal(t, 11, sp.ID())
+	}
+	if txt, err := sdk.String(12); assert.NoError(t, err) {
+		assert.Equal(t, "hello", txt)
+	}
+
+	// Iterators should yield the stored item
+	count := 0
+	for range sdk.Lands() {
+		count++
+	}
+	assert.Equal(t, 1, count)
+
+	count = 0
+	for range sdk.Items() {
+		count++
+	}
+	assert.Equal(t, 1, count)
+
+	count = 0
+	for range sdk.Gumps() {
+		count++
+	}
+	assert.Equal(t, 1, count)
+
+	count = 0
+	for range sdk.Hues() {
+		count++
+	}
+	assert.Equal(t, 1, count)
+
+	count = 0
+	for range sdk.Lights() {
+		count++
+	}
+	assert.Equal(t, 1, count)
+
+	count = 0
+	for range sdk.RadarColors() {
+		count++
+	}
+	assert.Equal(t, 1, count)
+
+	count = 0
+	for range sdk.Skills() {
+		count++
+	}
+	assert.Equal(t, 1, count)
+
+	count = 0
+	for range sdk.SkillGroups() {
+		count++
+	}
+	assert.Equal(t, 1, count)
+
+	count = 0
+	for range sdk.Sounds() {
+		count++
+	}
+	assert.Equal(t, 1, count)
+
+	count = 0
+	for range sdk.SpeechEntries() {
+		count++
+	}
+	assert.Equal(t, 1, count)
+
+	count = 0
+	for range sdk.Textures() {
+		count++
+	}
+	assert.Equal(t, 1, count)
+
+	count = 0
+	for range sdk.Strings() {
+		count++
+	}
+	assert.Equal(t, 1, count)
+
+	// Map and tile helpers
+	if m, err := sdk.Map(13); assert.NoError(t, err) {
+		if tile, err := m.TileAt(1, 1); assert.NoError(t, err) {
+			assert.Equal(t, uint16(0x100), tile.ID)
+		}
+		img, err := m.Image()
+		assert.NoError(t, err)
+		assert.Equal(t, 2, img.Bounds().Dx())
+		assert.Equal(t, 2, img.Bounds().Dy())
+	}
+	if multi, err := sdk.Multi(14); assert.NoError(t, err) {
+		assert.Len(t, multi.Items, 1)
+	}
+	_, err = sdk.MultiFromCSV(nil)
+	assert.Error(t, err)
+
+	// Font helpers
+	if f, err := sdk.FontUnicode(); assert.NoError(t, err) {
+		assert.NotNil(t, f)
+	}
+	if fonts, err := sdk.Font(); assert.NoError(t, err) {
+		assert.Len(t, fonts, 1)
+	}
+
+	// BasePath should be empty and Close should succeed
+	assert.Equal(t, "", sdk.BasePath())
+	assert.NoError(t, sdk.Close())
+}
+
+func TestMockSDK_NotFound(t *testing.T) {
+	sdk := New()
+	_, err := sdk.Land(999)
+	assert.ErrorIs(t, err, ErrNotFound)
+	_, err = sdk.Item(999)
+	assert.ErrorIs(t, err, ErrNotFound)
+	_, err = sdk.Gump(999)
+	assert.ErrorIs(t, err, ErrNotFound)
+	_, err = sdk.Hue(999)
+	assert.ErrorIs(t, err, ErrNotFound)
+	_, err = sdk.Light(999)
+	assert.ErrorIs(t, err, ErrNotFound)
+	_, err = sdk.RadarColor(999)
+	assert.ErrorIs(t, err, ErrNotFound)
+	_, err = sdk.Skill(999)
+	assert.ErrorIs(t, err, ErrNotFound)
+	_, err = sdk.SkillGroup(999)
+	assert.ErrorIs(t, err, ErrNotFound)
+	_, err = sdk.Sound(999)
+	assert.ErrorIs(t, err, ErrNotFound)
+	_, err = sdk.Texture(999)
+	assert.ErrorIs(t, err, ErrNotFound)
+	_, err = sdk.SpeechEntry(999)
+	assert.ErrorIs(t, err, ErrNotFound)
+	_, err = sdk.Map(999)
+	assert.ErrorIs(t, err, ErrNotFound)
+	_, err = sdk.Multi(999)
+	assert.ErrorIs(t, err, ErrNotFound)
+	_, err = sdk.FontUnicode()
+	assert.ErrorIs(t, err, ErrNotFound)
+	_, err = sdk.Font()
+	assert.ErrorIs(t, err, ErrNotFound)
+	_, err = sdk.String(999)
+	assert.ErrorIs(t, err, ErrNotFound)
+}


### PR DESCRIPTION
## Summary
- share `ErrNotFound` constant across the mock SDK
- replace inline `not found` errors with `ErrNotFound`
- assert `ErrNotFound` in tests

## Testing
- `go test ./mock -v`
- `go test ./... -count=1` *(fails: client directory does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68550c28d34c83228f6d5e207f64c3d7