### PR TITLE
fix: length argument is now properly propagated for UOP files

### DIFF
--- a/gump_test.go
+++ b/gump_test.go
@@ -25,9 +25,6 @@ func TestGump(t *testing.T) {
 			count := 0
 			for range sdk.Gumps() {
 				count++
-				if count > 1000 {
-					break
-				}
 			}
 			assert.Greater(t, count, 0)
 		})
@@ -77,6 +74,15 @@ func TestGump(t *testing.T) {
 			gump, err := sdk.Gump(0xFFFFF) // Very high ID
 			assert.Error(t, err, "Should error on invalid gump ID")
 			assert.Nil(t, gump, "Should not return a gump for invalid ID")
+		})
+	})
+
+	t.Run("Gump40018", func(t *testing.T) {
+		runWith(t, func(sdk *SDK) {
+			gump, err := sdk.Gump(40018)
+			require.NoError(t, err)
+			require.NotNil(t, gump)
+			assert.NotNil(t, gump.Image)
 		})
 	})
 }

--- a/internal/uofile/file.go
+++ b/internal/uofile/file.go
@@ -76,7 +76,7 @@ func WithCount(count int) Option {
 // WithIndexLength sets the index length for UOP files
 func WithIndexLength(length int) Option {
 	return func(f *File) {
-		f.uopOpts = append(f.uopOpts, uop.WithIndexLength(length))
+		f.uopOpts = append(f.uopOpts, uop.WithLength(length))
 	}
 }
 

--- a/internal/uop/uop.go
+++ b/internal/uop/uop.go
@@ -42,15 +42,14 @@ type Entry6D struct {
 
 // Reader implements the interface for reading UOP files
 type Reader struct {
-	file      *mmap.File  // File handle
-	info      os.FileInfo // File information
-	entries   []Entry6D   // Map of entries by logical index or hash
-	length    int         // Length of the file
-	idxLength int         // Length of the index
-	ext       string      // File extension
-	closed    bool        // Flag to track if reader is closed
-	hasextra  bool        // Flag to indicate if extra data is present
-	strict    bool        // Flag to indicate if the reader should skip not found hashes
+	file     *mmap.File  // File handle
+	info     os.FileInfo // File information
+	entries  []Entry6D   // Map of entries by logical index or hash
+	length   int         // Length of the file
+	ext      string      // File extension
+	closed   bool        // Flag to track if reader is closed
+	hasextra bool        // Flag to indicate if extra data is present
+	strict   bool        // Flag to indicate if the reader should skip not found hashes
 }
 
 // Open creates a new UOP file reader
@@ -66,10 +65,10 @@ func Open(filename string, length int, options ...Option) (*Reader, error) {
 	}
 
 	r := &Reader{
-		file:      file,
-		info:      info,
-		ext:       ".dat",
-		idxLength: 0xFFFFFFFF,
+		file:   file,
+		info:   info,
+		ext:    ".dat",
+		length: length,
 	}
 
 	// Apply any provided options
@@ -175,7 +174,7 @@ func (r *Reader) parseFile() error {
 				continue
 			}
 
-			if entryIdx < 0 || entryIdx > r.idxLength {
+			if entryIdx < 0 || entryIdx > r.length {
 				return fmt.Errorf("hashes dictionary and files collection have different count of entries")
 			}
 

--- a/internal/uop/uop_opts.go
+++ b/internal/uop/uop_opts.go
@@ -20,10 +20,10 @@ func WithExtension(ext string) Option {
 	}
 }
 
-// WithIndexLength sets the length of the index.
-func WithIndexLength(length int) Option {
+// WithLength sets the length of the index.
+func WithLength(length int) Option {
 	return func(r *Reader) {
-		r.idxLength = length
+		r.length = length
 	}
 }
 

--- a/internal/uop/uop_test.go
+++ b/internal/uop/uop_test.go
@@ -42,7 +42,7 @@ func TestNewReader(t *testing.T) {
 func TestEntryOperations(t *testing.T) {
 	testUOP := filepath.Join(uotest.Path(), "artLegacyMUL.uop")
 
-	reader, err := Open(testUOP, 0x14000, WithExtension(".tga"), WithIndexLength(0x13FDC))
+	reader, err := Open(testUOP, 0x14000, WithExtension(".tga"), WithLength(0x13FDC))
 	require.NoError(t, err)
 	defer reader.Close()
 


### PR DESCRIPTION
This pull request refactors how index length is handled in the UOP file reader logic, simplifying the API and internal data structures. The main change is replacing the separate `idxLength` field and related option with a unified `length` field and option, which streamlines both usage and implementation. Additionally, a new test case is added for the `Gump` functionality.

**UOP file reader refactor:**

* Replaced the `idxLength` field in the `Reader` struct with `length`, removing the redundant index length field and simplifying the internal state (`internal/uop/uop.go`).
* Changed the option function `WithIndexLength` to `WithLength`, updating its usage in both the file reader and its tests (`internal/uop/uop.go`, `internal/uop/uop_opts.go`, `internal/uofile/file.go`, `internal/uop/uop_test.go`). [[1]](diffhunk://#diff-b758fb2562f70e669e5a4b263d5c0881ddf650d4949f20d5ab7faa38be55ecd4L23-R26) [[2]](diffhunk://#diff-a688bdaeb354be306996ca6bacb52b4252402febd4351adabb9bdaef6e1c4b25L79-R79) [[3]](diffhunk://#diff-6eddb0221bdde97fbf8b4a92a014cb743a6516294d858dc30bd521a79633fae8L45-R45)
* Updated the logic in `Open` and `parseFile` to use the unified `length` field for index bounds checking, further consolidating the codebase (`internal/uop/uop.go`). [[1]](diffhunk://#diff-d4b83fa3c1a4a942528a539cdaad103c7da6bea977e0f89dd955d134242f06b6L72-R71) [[2]](diffhunk://#diff-d4b83fa3c1a4a942528a539cdaad103c7da6bea977e0f89dd955d134242f06b6L178-R177)

**Test improvements:**

* Added a new test case `Gump40018` to ensure that `sdk.Gump(40018)` returns a valid gump and image (`gump_test.go`).
* Removed a test loop break condition, allowing the test to iterate through all gumps instead of stopping at 1000 (`gump_test.go`).