### PR TITLE
fix: correct width and height assignment in gump decoding logic for MUL

### DIFF
--- a/gump.go
+++ b/gump.go
@@ -68,8 +68,8 @@ func decodeGump(data []byte, extra uint64) (*Gump, error) {
 	height := int((extra >> 32) & 0xFFFF)
 
 	if extra < math.MaxUint32 {
-		width = int(extra & 0xFFFF)
-		height = int((extra >> 16) & 0xFFFF)
+		height = int(extra & 0xFFFF)
+		width = int((extra >> 16) & 0xFFFF)
 	}
 
 	// Sanity check
@@ -95,6 +95,9 @@ func decodeGumpData(data []byte, width, height int) (image.Image, error) {
 	if len(data) < need {
 		return nil, fmt.Errorf("data too short for lookup table")
 	}
+
+	// Save binary data to file
+	//	os.WriteFile("gump-KO.bin", data, 0644)
 
 	// Parse lookup table (height * uint32).
 	lookup := make([]uint32, height)


### PR DESCRIPTION
This pull request makes a minor fix to the logic for decoding the `width` and `height` values from the `extra` parameter in the `decodeGump` function, and adds a commented-out debug statement in the `decodeGumpData` function. The main impact is to ensure that the dimensions are extracted correctly when `extra < math.MaxUint32`.

- **Bug fix: Gump dimension decoding**
  * Swapped the order of width and height extraction from `extra` in `decodeGump`, so that `height` and `width` are correctly assigned when `extra < math.MaxUint32`.

- **Debugging: Data output**
  * Added a commented-out line to optionally save the binary data to a file in `decodeGumpData` for debugging purposes.