### PR TITLE
Change the font API

### DIFF
--- a/font_test.go
+++ b/font_test.go
@@ -17,26 +17,39 @@ func TestFont_Load(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Len(t, fonts, 10)
 			for i, font := range fonts {
-				c := font.Character('A')
+				c := font.Rune('A')
 				assert.NotNil(t, c, "Font %d: missing 'A'", i)
-				assert.Greater(t, c.Width, 0)
-				assert.Greater(t, c.Height, 0)
+				assert.Greater(t, c.Width, int8(0))
+				assert.Greater(t, c.Height, int8(0))
 				assert.NotNil(t, c.Image)
 				assert.NoError(t, savePng(c.Image, "test/font_ascii.png"))
 			}
 		})
 
 		t.Run("Unicode", func(t *testing.T) {
-			_, err := sdk.FontUnicode()
+			font, err := sdk.FontUnicode(1)
 			assert.NoError(t, err)
-
-			font, err := sdk.FontUnicode()
-			assert.NoError(t, err)
-			c := font.Character('你')
+			c := font.Rune('你')
 			assert.NotNil(t, c)
-			assert.GreaterOrEqual(t, c.Width, 0)
-			assert.GreaterOrEqual(t, c.Height, 0)
+			assert.GreaterOrEqual(t, c.Width, int8(0))
+			assert.GreaterOrEqual(t, c.Height, int8(0))
 			assert.NoError(t, savePng(c.Image, "test/font_utf8.png"))
+		})
+
+		t.Run("Space", func(t *testing.T) {
+			font, err := sdk.FontUnicode(1)
+			assert.NoError(t, err)
+			w, h := font.Size(" ")
+			assert.Equal(t, 0, h)
+			assert.Equal(t, 8, w)
+		})
+
+		t.Run("Size", func(t *testing.T) {
+			font, err := sdk.FontUnicode(1)
+			assert.NoError(t, err)
+			w, h := font.Size("Hello, World!")
+			assert.Equal(t, 15, h)
+			assert.Equal(t, 61, w)
 		})
 	})
 }

--- a/mock/sdk_test.go
+++ b/mock/sdk_test.go
@@ -31,8 +31,8 @@ func TestMockSDK_AddAndRetrieve(t *testing.T) {
 // dummyFont implements ultima.Font for testing purposes.
 type dummyFont struct{}
 
-func (dummyFont) Character(r rune) *ultima.FontRune { return &ultima.FontRune{} }
-func (dummyFont) Size(string) (int, int)            { return 0, 0 }
+func (dummyFont) Rune(r rune) *ultima.Rune { return &ultima.Rune{} }
+func (dummyFont) Size(string) (int, int)   { return 0, 0 }
 
 // setup creates a mock SDK populated with sample data covering the full
 // exported surface of the SDK type.

--- a/sdk_files.go
+++ b/sdk_files.go
@@ -144,8 +144,12 @@ func (s *SDK) loadFont() (*uofile.File, error) {
 }
 
 // loadFontUnicode loads the Unicode font file
-func (s *SDK) loadFontUnicode() (*uofile.File, error) {
-	return s.load([]string{"unifont1.mul"}, 0)
+func (s *SDK) loadFontUnicode(n int) (*uofile.File, error) {
+	if n <= 0 {
+		return s.load([]string{"unifont.mul"}, 0)
+	}
+
+	return s.load([]string{fmt.Sprintf("unifont%d.mul", n)}, 0)
 }
 
 // loadAnimdata loads the animdata file


### PR DESCRIPTION
This pull request refactors the font handling code to improve type safety, consistency, and Unicode font support. The main changes include renaming and updating the character metadata struct, standardizing method names, and introducing better handling for Unicode font files. Several related tests have also been updated and expanded.

### API and Type Refactoring

* Renamed `FontRune` struct to `Rune`, converted its fields from `int` to `int8`, and updated all references to use the new type for character metadata and bitmap. This improves memory efficiency and clarifies usage. [[1]](diffhunk://#diff-2165e2d5794f2a7b197c92397c353f1e34f977e89b111f1bdb205c1aee21bbc5L13-R34) [[2]](diffhunk://#diff-2165e2d5794f2a7b197c92397c353f1e34f977e89b111f1bdb205c1aee21bbc5L78-R88) [[3]](diffhunk://#diff-2165e2d5794f2a7b197c92397c353f1e34f977e89b111f1bdb205c1aee21bbc5L151-R160) [[4]](diffhunk://#diff-2165e2d5794f2a7b197c92397c353f1e34f977e89b111f1bdb205c1aee21bbc5L176-R229)
* Changed the `Font` interface method from `Character(rune)` to `Rune(rune)` for both ASCII and Unicode fonts, updating all usages to match the new method name and signature. [[1]](diffhunk://#diff-2165e2d5794f2a7b197c92397c353f1e34f977e89b111f1bdb205c1aee21bbc5L13-R34) [[2]](diffhunk://#diff-2165e2d5794f2a7b197c92397c353f1e34f977e89b111f1bdb205c1aee21bbc5L176-R229) [[3]](diffhunk://#diff-17b6d56d938e115ab311e5c52bbeb7f33588c42763c552c0e0c79d7cb5f8bc3fL34-R34)

### Unicode Font Handling

* Added support for loading multiple Unicode font files via the new `FontUnicode(n int)` and `loadFontUnicode(n int)` methods, allowing selection of specific font variants. [[1]](diffhunk://#diff-2165e2d5794f2a7b197c92397c353f1e34f977e89b111f1bdb205c1aee21bbc5L13-R34) [[2]](diffhunk://#diff-d6d44ac3a6a065a65fc2db6b1da92929c16073f86f69949453165fae58ebceffL147-R152)
* Standardized the Unicode font offset table size using the new `unicodeFontSize` constant, improving clarity and maintainability. [[1]](diffhunk://#diff-2165e2d5794f2a7b197c92397c353f1e34f977e89b111f1bdb205c1aee21bbc5L13-R34) [[2]](diffhunk://#diff-2165e2d5794f2a7b197c92397c353f1e34f977e89b111f1bdb205c1aee21bbc5L43-R72)

### Test Improvements

* Updated all tests to use the new `Rune` struct and method names, and improved type assertions for width and height. Added new test cases for space character sizing and overall string sizing in Unicode fonts.
* Updated dummy font implementation in tests to match the new interface and struct names.