### PR TITLE
Implement full text rendering

### DIFF
--- a/font_test.go
+++ b/font_test.go
@@ -51,5 +51,13 @@ func TestFont_Load(t *testing.T) {
 			assert.Equal(t, 15, h)
 			assert.Equal(t, 73, w)
 		})
+
+		t.Run("Text", func(t *testing.T) {
+			font, err := sdk.FontUnicode(1)
+			assert.NoError(t, err)
+			img := sdk.Text(font, "Hello, World!", 1)
+			assert.NotNil(t, img)
+			assert.NoError(t, savePng(img, "test/font_text.png"))
+		})
 	})
 }

--- a/mock/sdk.go
+++ b/mock/sdk.go
@@ -216,6 +216,10 @@ func (s *SDK) Font() ([]ultima.Font, error) {
 	return s.Fonts, nil
 }
 
+func (s *SDK) Text(font ultima.Font, text string, hue int) image.Image {
+	return image.NewRGBA(image.Rect(0, 0, 1, 1))
+}
+
 func (s *SDK) Gump(id int) (*ultima.Gump, error) {
 	v, ok := s.GumpsMap[id]
 	if !ok {

--- a/mock/sdk.go
+++ b/mock/sdk.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"image"
 
-	"github.com/kelindar/ultima-sdk"
 	"iter"
+
+	"github.com/kelindar/ultima-sdk"
 )
 
 var ErrNotFound = errors.New("not found")
@@ -201,7 +202,7 @@ func (s *SDK) StringsWithLang(lang string) iter.Seq2[int, string] {
 	}
 }
 
-func (s *SDK) FontUnicode() (ultima.Font, error) {
+func (s *SDK) FontUnicode(int) (ultima.Font, error) {
 	if s.UnicodeFont == nil {
 		return nil, ErrNotFound
 	}

--- a/mock/sdk_test.go
+++ b/mock/sdk_test.go
@@ -204,7 +204,7 @@ func TestMockSDK_Methods(t *testing.T) {
 	assert.Error(t, err)
 
 	// Font helpers
-	if f, err := sdk.FontUnicode(); assert.NoError(t, err) {
+	if f, err := sdk.FontUnicode(1); assert.NoError(t, err) {
 		assert.NotNil(t, f)
 	}
 	if fonts, err := sdk.Font(); assert.NoError(t, err) {
@@ -244,7 +244,7 @@ func TestMockSDK_NotFound(t *testing.T) {
 	assert.ErrorIs(t, err, ErrNotFound)
 	_, err = sdk.Multi(999)
 	assert.ErrorIs(t, err, ErrNotFound)
-	_, err = sdk.FontUnicode()
+	_, err = sdk.FontUnicode(999)
 	assert.ErrorIs(t, err, ErrNotFound)
 	_, err = sdk.Font()
 	assert.ErrorIs(t, err, ErrNotFound)


### PR DESCRIPTION
This pull request adds Unicode text rendering with hue coloring to the SDK, along with supporting changes to the font API and mock implementations. The main improvement is the new `Text` method for rendering colored text images, and the API for loading Unicode fonts now accepts a font index parameter for greater flexibility. The changes are covered by new and updated unit tests.

### Unicode text rendering and coloring

* Added `SDK.Text(font, text, hue)` method to render Unicode text as an image with hue coloring, including the helper `applyHueToImage` for per-glyph colorization. (`font.go` [font.goR269-R374](diffhunk://#diff-2165e2d5794f2a7b197c92397c353f1e34f977e89b111f1bdb205c1aee21bbc5R269-R374))
* Imported `image/color` and `image/draw` to support image manipulation for text rendering. (`font.go` [font.goR10-R11](diffhunk://#diff-2165e2d5794f2a7b197c92397c353f1e34f977e89b111f1bdb205c1aee21bbc5R10-R11))

### Font API improvements

* Changed `FontUnicode()` to accept a font index parameter for selecting specific Unicode fonts. (`mock/sdk.go` [mock/sdk.goL204-R205](diffhunk://#diff-07a462656690a53328663509696dece165046abff029f1bba55a21a41bbf5039L204-R205))
* Updated mock SDK to implement the new `FontUnicode(int)` signature and added a stub for the new `Text` method. (`mock/sdk.go` [mock/sdk.goR219-R222](diffhunk://#diff-07a462656690a53328663509696dece165046abff029f1bba55a21a41bbf5039R219-R222))

### Testing enhancements

* Added a test for the new `Text` method to verify Unicode text rendering and image output. (`font_test.go` [font_test.goR54-R61](diffhunk://#diff-f8977fb4319c5560decf192c43e595fc6536ae6615d5fbd4def862249d3b6816R54-R61))
* Updated mock SDK tests to use the new `FontUnicode(int)` signature and to check error handling for missing fonts. (`mock/sdk_test.go` [[1]](diffhunk://#diff-17b6d56d938e115ab311e5c52bbeb7f33588c42763c552c0e0c79d7cb5f8bc3fL207-R207) [[2]](diffhunk://#diff-17b6d56d938e115ab311e5c52bbeb7f33588c42763c552c0e0c79d7cb5f8bc3fL247-R247)